### PR TITLE
Added isMultiline for the project status page's title column fields  …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11497,7 +11497,7 @@
             "dev": true
         },
         "sp-js-provisioning": {
-            "version": "git+https://github.com/Puzzlepart/sp-js-provisioning.git#64e73472b4b582a506bf7530ad5b9b34a88707ca",
+            "version": "git+https://github.com/Puzzlepart/sp-js-provisioning.git#db633124db5593bb76a23f64bf2efb74c2cebc1a",
             "dev": true,
             "requires": {
                 "object.omit": "3.0.0",

--- a/src/js/WebParts/ProjectStatus/Section/SectionList/index.tsx
+++ b/src/js/WebParts/ProjectStatus/Section/SectionList/index.tsx
@@ -67,6 +67,7 @@ export default class SectionList extends React.Component<ISectionListProps, ISec
         switch (column.fieldName) {
             case "Title": {
                 let defaultDisplayFormUrl = `${listData.defaultDisplayFormUrl}?ID=${item.ID}`;
+                column.isMultiline = true;
                 return (
                     <a
                         href={defaultDisplayFormUrl}


### PR DESCRIPTION
…#547

- [Status report snapshot before](https://user-images.githubusercontent.com/28678468/41585655-fdbf5134-73aa-11e8-9257-40f4fb0eeee8.png)
- [Status report snapshot after](https://user-images.githubusercontent.com/28678468/41585660-0245e8f8-73ab-11e8-8613-6d735930ae3b.png)