### PR TITLE
#692 better porfolio overview sizing

### DIFF
--- a/src/css/components/ProjectInfo.styl
+++ b/src/css/components/ProjectInfo.styl
@@ -11,3 +11,8 @@
         }
     }
 }
+
+#pp-dynamicportfolio {
+    height: calc(100vh - 195px);
+    width: calc(100vw - 240px);
+    }

--- a/src/css/components/ProjectInfo.styl
+++ b/src/css/components/ProjectInfo.styl
@@ -1,9 +1,10 @@
 .pp-projectInfo {
     .pp-projectInfoInner {
         .prop {
-            margin-bottom: 5px;    
+            margin-bottom: 5px;
         }
     }
+
     .pp-project-actions {
         > a {
             display: block;
@@ -15,4 +16,9 @@
 #pp-dynamicportfolio {
     height: calc(100vh - 195px);
     width: calc(100vw - 240px);
+
+    div[class*='stickyAbove'] {
+        overflow: hidden;
+        overflow-x: hidden;
     }
+}

--- a/src/js/WebParts/DynamicPortfolio/index.tsx
+++ b/src/js/WebParts/DynamicPortfolio/index.tsx
@@ -68,14 +68,14 @@ export default class DynamicPortfolio extends BaseWebPart<IDynamicPortfolioProps
         const { isLoading, errorMessage, isChangingView } = this.state;
         if (errorMessage) {
             return (
-                <div style={{ height: "80vh", position: "relative", maxHeight: "inherit" }} onScroll={this.handleContainerScroll}>
+                <div style={{ height: "100%", position: "relative", maxHeight: "inherit" }} onScroll={this.handleContainerScroll}>
                     <MessageBar messageBarType={errorMessage.type}>{errorMessage.message}</MessageBar>
                 </div>
             );
         }
         if (isLoading) {
             return (
-                <div style={{ height: "80vh", position: "relative", maxHeight: "inherit" }} onScroll={this.handleContainerScroll}>
+                <div style={{ height: "100%", position: "relative", maxHeight: "inherit" }} onScroll={this.handleContainerScroll}>
                     <Spinner label={this.props.loadingText} type={SpinnerType.large} />
                 </div>
             );
@@ -83,7 +83,7 @@ export default class DynamicPortfolio extends BaseWebPart<IDynamicPortfolioProps
         if (isChangingView) {
             const loadingText = String.format(__.getResource("DynamicPortfolio_LoadingViewText"), isChangingView.name);
             return (
-                <div style={{ height: "80vh", position: "relative", maxHeight: "inherit" }} onScroll={this.handleContainerScroll}>
+                <div style={{ height: "100%", position: "relative", maxHeight: "inherit" }} onScroll={this.handleContainerScroll}>
                     {this.renderCommandBar()}
                     <div style={{ paddingTop: 20 }}>
                         <Spinner label={loadingText} type={SpinnerType.large} />
@@ -93,7 +93,7 @@ export default class DynamicPortfolio extends BaseWebPart<IDynamicPortfolioProps
         }
 
         return (
-            <div style={{ height: "80vh", position: "relative", maxHeight: "inherit" }} onScroll={this.handleContainerScroll}>
+            <div style={{ height: "100%", position: "relative", maxHeight: "inherit" }} onScroll={this.handleContainerScroll}>
                 <ScrollablePane>
                     {this.renderCommandBar()}
                     {this.renderSearchBox()}

--- a/templates/root/SitePages/Portfolio.aspx
+++ b/templates/root/SitePages/Portfolio.aspx
@@ -29,9 +29,6 @@
         #s4-workspace {
             height: auto !important;  
         }
-        .ms-ScrollablePane div[class*='contentContainer'] {
-            bottom: 25px !important;
-        }
         div[class*='stickyAbove'] {
             overflow: hidden !important;  
         }

--- a/templates/root/SitePages/Portfolio.aspx
+++ b/templates/root/SitePages/Portfolio.aspx
@@ -29,8 +29,5 @@
         #s4-workspace {
             height: auto !important;  
         }
-        div[class*='stickyAbove'] {
-            overflow: hidden !important;  
-        }
     </style>
 </asp:Content>


### PR DESCRIPTION
Portfolio overview now scales to 100% of viewport width and height, minus the height of the suitebar and width of the quicklaunch