### PR TITLE
Ability to add and show subtext to phases

### DIFF
--- a/src/js/WebParts/ProjectPhases/ProjectPhase/ProjectPhaseIcon/index.tsx
+++ b/src/js/WebParts/ProjectPhases/ProjectPhase/ProjectPhaseIcon/index.tsx
@@ -14,7 +14,7 @@ const ProjectPhaseIcon = (props: IProjectPhaseIconProps) => {
             <div className={['phaseIcon', ...props.classList].join(' ')}>
                 <span className={'phaseLetter'}>{props.phase.PhaseLetter}</span>
                 <span className={'phaseText'} hidden={isGate || !props.phase.ShowPhaseText}>{props.phase.Name}</span>
-                <span className={'phaseSubText'}></span>
+                <span className={'phaseSubText'}>{props.phase.PhaseSubText}</span>
             </div>
             <ProjectPhaseIterations phase={props.phase} phaseIterations={props.phaseIterations} />
         </a>

--- a/src/js/WebParts/ProjectPhases/ProjectPhasesData/PhaseModel.ts
+++ b/src/js/WebParts/ProjectPhases/ProjectPhasesData/PhaseModel.ts
@@ -13,7 +13,7 @@ export default class PhaseModel {
     public ShowPhaseText?: boolean;
     public IsIncremental?: boolean;
     public Type: string;
-    public SubText: string;
+    public PhaseSubText: string;
     public PhaseLetter: string;
     public Checklist: { stats: { [key: string]: number }; items: IChecklistItem[]; defaultViewUrl: string };
 
@@ -39,7 +39,7 @@ export default class PhaseModel {
         this.ShowOnFrontpage = properties.ShowOnFrontpage !== 'false'
         this.ShowPhaseText = properties.ShowPhaseText !== 'false'
         this.IsIncremental = properties.IsIncremental === 'true' && gatesEnabled
-        this.SubText = properties.PhaseSubText
+        this.PhaseSubText = properties.PhaseSubText
         this.PhaseLetter = properties.PhaseLetter || this.Name[0]
         this.initChecklist()
         return this


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message
- [X] Check your code additions will fail linting checks
- [X] Remember: After PR is closed, add PR description to [Changelog](https://github.com/Puzzlepart/prosjektportalen/blob/dev/CHANGELOG.md)

### Description

Ability to add and show subtext underneath each phase in the phase selector webpart for every project #764

### How to test

Add the following property to a Phase in the termstore like so:
![image](https://user-images.githubusercontent.com/28678468/92884030-c120e000-f411-11ea-8f0c-d2ef80021e0f.png)
