### PR TITLE
Added ProjectStats highcharts styling

### DIFF
--- a/src/css/components/ProjectStats.styl
+++ b/src/css/components/ProjectStats.styl
@@ -1,0 +1,3 @@
+.highcharts-background {
+    fill:none;
+    }


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message
- [x] Check your code additions will fail linting checks
- [x] Remember: After PR is closed, add PR description to [Changelog](https://github.com/Puzzlepart/prosjektportalen/blob/dev/CHANGELOG.md)

### Description

Added fill:none to highcharts-background. 

In some cases, descriptive text in ProjectStats (and ProgramProjectStats additionally, as it uses the main.css file) is rendered behind the highcharts-background div. Highcharts-background being on top and filled with #FFFFFF, led to labels and descriptive text being invisible.

### How to test

As this is not a bug in all instances, it is difficult to test all, but to test breakage:

View ProjectStats.aspx (if text is visible, it's fine)
Build .css file
Upload main.css
View ProjectStats.aspx

If text is visible, the fix hasn't broken anything existing.

### Relevant issues (if applicable)
None

💔Thank you!
