### PR TITLE
Added ability to hide list and RiskShowPostAction in RiskMatrix webpart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 2.7.1 - TBA
 
+### Added
+
+- Added ability to hide list and RiskShowPostAction in RiskMatrix webpart #777
+
 ### Fixed
 
 - Stopped using SPWebUrl managed property, which has a bug in SharePoint on-premises #766

--- a/src/js/WebParts/RiskMatrix/IRiskMatrixProps.ts
+++ b/src/js/WebParts/RiskMatrix/IRiskMatrixProps.ts
@@ -11,6 +11,8 @@ export default interface IRiskMatrixProps extends React.HTMLAttributes<HTMLEleme
     showViewSelector?: boolean;
     showProjectSelector?: boolean;
     showProjectColumn?: boolean;
+    showProjectList?: boolean;
+    showToggle?: boolean;
     hideLabelsBreakpoint?: number;
     dataSourceName?: string;
     queryTemplate?: string;
@@ -82,6 +84,8 @@ export const RiskMatrixDefaultProps: Partial<IRiskMatrixProps> = {
     showViewSelector: true,
     showProjectSelector: true,
     showProjectColumn: true,
+    showProjectList: true,
+    showToggle: true,
     hideLabelsBreakpoint: 900,
     rowLimit: 500,
     postActionShowOriginal: false,

--- a/src/js/WebParts/RiskMatrix/IRiskMatrixProps.ts
+++ b/src/js/WebParts/RiskMatrix/IRiskMatrixProps.ts
@@ -11,7 +11,7 @@ export default interface IRiskMatrixProps extends React.HTMLAttributes<HTMLEleme
     showViewSelector?: boolean;
     showProjectSelector?: boolean;
     showProjectColumn?: boolean;
-    showProjectList?: boolean;
+    showUncertaintiesList?: boolean;
     showToggle?: boolean;
     hideLabelsBreakpoint?: number;
     dataSourceName?: string;
@@ -84,7 +84,7 @@ export const RiskMatrixDefaultProps: Partial<IRiskMatrixProps> = {
     showViewSelector: true,
     showProjectSelector: true,
     showProjectColumn: true,
-    showProjectList: true,
+    showUncertaintiesList: true,
     showToggle: true,
     hideLabelsBreakpoint: 900,
     rowLimit: 500,

--- a/src/js/WebParts/RiskMatrix/index.tsx
+++ b/src/js/WebParts/RiskMatrix/index.tsx
@@ -72,6 +72,8 @@ export default class RiskMatrix extends React.Component<IRiskMatrixProps, IRiskM
             loadingText,
             showViewSelector,
             showProjectSelector,
+            showProjectList,
+            showToggle,
             dataSourceName,
             columns,
         } = this.props
@@ -128,11 +130,13 @@ export default class RiskMatrix extends React.Component<IRiskMatrixProps, IRiskM
                                             {this.renderRows(items)}
                                         </tbody>
                                     </table>
+                                    <div hidden={!showToggle}>
                                     <Toggle
                                         onChanged={postAction => this.setState({ postAction })}
                                         label={__.getResource('ProjectStatus_RiskShowPostActionLabel')}
                                         onText={__.getResource('String_Yes')}
                                         offText={__.getResource('String_No')} />
+                                        </div>
                                 </div>
                                 <div hidden={!dataSourceName}>
                                     <div hidden={!showProjectSelector}>
@@ -142,6 +146,7 @@ export default class RiskMatrix extends React.Component<IRiskMatrixProps, IRiskM
                                             options={this.getProjectOptions()}
                                             onChanged={opt => this.setState({ selectedProject: opt })} />
                                     </div>
+                                    <div hidden={!showProjectList}>
                                     <List
                                         items={items}
                                         columns={this.props.showProjectColumn ? columns : columns.filter(c => c.key !== 'SiteTitle')}
@@ -149,6 +154,7 @@ export default class RiskMatrix extends React.Component<IRiskMatrixProps, IRiskM
                                         pathKey='url'
                                         siteTitleKey='siteTitle'
                                         showCommandBar={false} />
+                                        </div>
                                 </div>
                             </div>
                         )}

--- a/src/js/WebParts/RiskMatrix/index.tsx
+++ b/src/js/WebParts/RiskMatrix/index.tsx
@@ -131,12 +131,12 @@ export default class RiskMatrix extends React.Component<IRiskMatrixProps, IRiskM
                                         </tbody>
                                     </table>
                                     <div hidden={!showToggle}>
-                                    <Toggle
-                                        onChanged={postAction => this.setState({ postAction })}
-                                        label={__.getResource('ProjectStatus_RiskShowPostActionLabel')}
-                                        onText={__.getResource('String_Yes')}
-                                        offText={__.getResource('String_No')} />
-                                        </div>
+                                        <Toggle
+                                            onChanged={postAction => this.setState({ postAction })}
+                                            label={__.getResource('ProjectStatus_RiskShowPostActionLabel')}
+                                            onText={__.getResource('String_Yes')}
+                                            offText={__.getResource('String_No')} />
+                                    </div>
                                 </div>
                                 <div hidden={!dataSourceName}>
                                     <div hidden={!showProjectSelector}>
@@ -147,14 +147,14 @@ export default class RiskMatrix extends React.Component<IRiskMatrixProps, IRiskM
                                             onChanged={opt => this.setState({ selectedProject: opt })} />
                                     </div>
                                     <div hidden={!showUncertaintiesList}>
-                                    <List
-                                        items={items}
-                                        columns={this.props.showProjectColumn ? columns : columns.filter(c => c.key !== 'SiteTitle')}
-                                        webUrlKey='webUrl'
-                                        pathKey='url'
-                                        siteTitleKey='siteTitle'
-                                        showCommandBar={false} />
-                                        </div>
+                                        <List
+                                            items={items}
+                                            columns={this.props.showProjectColumn ? columns : columns.filter(c => c.key !== 'SiteTitle')}
+                                            webUrlKey='webUrl'
+                                            pathKey='url'
+                                            siteTitleKey='siteTitle'
+                                            showCommandBar={false} />
+                                    </div>
                                 </div>
                             </div>
                         )}

--- a/src/js/WebParts/RiskMatrix/index.tsx
+++ b/src/js/WebParts/RiskMatrix/index.tsx
@@ -72,7 +72,7 @@ export default class RiskMatrix extends React.Component<IRiskMatrixProps, IRiskM
             loadingText,
             showViewSelector,
             showProjectSelector,
-            showProjectList,
+            showUncertaintiesList,
             showToggle,
             dataSourceName,
             columns,
@@ -146,7 +146,7 @@ export default class RiskMatrix extends React.Component<IRiskMatrixProps, IRiskM
                                             options={this.getProjectOptions()}
                                             onChanged={opt => this.setState({ selectedProject: opt })} />
                                     </div>
-                                    <div hidden={!showProjectList}>
+                                    <div hidden={!showUncertaintiesList}>
                                     <List
                                         items={items}
                                         columns={this.props.showProjectColumn ? columns : columns.filter(c => c.key !== 'SiteTitle')}


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message
- [x] Check your code additions will fail linting checks
- [x] Remember: After PR is closed, add PR description to [Changelog](https://github.com/Puzzlepart/prosjektportalen/blob/dev/CHANGELOG.md)

### Description

Added two Riskmatrix props to have the opportunity to hide the and uncertainty list and toggle button. 

### How to test

- [ ] 1. Add the risk matrix web part with the following dataprops: 

```<div id="pp-riskMatrix" data-props='{"showUncertaintiesList":0, "showToggle":0}' </div>```
to the web part. The toggle button and and uncertainty list should now be hidden. 

### Relevant issues (if applicable)

#776 
